### PR TITLE
Avoid leaving cloudflared orphan process

### DIFF
--- a/cfdtunnel/cfdtunnel.go
+++ b/cfdtunnel/cfdtunnel.go
@@ -91,7 +91,7 @@ func commandKill(cmd *exec.Cmd) {
 func (args Arguments) runSubCommand() {
 	log.Debugf("Running subcommand: %v", args.Command)
 	if !checkSubCommandExists(args.Command) {
-		os.Exit(1)
+		return
 	}
 
 	output, err := exec.Command(args.Command, args.Args...).CombinedOutput()
@@ -99,7 +99,7 @@ func (args Arguments) runSubCommand() {
 	fmt.Println(string(output))
 
 	if err != nil {
-		log.Fatalf("An error occurred trying to run the command %v: %v", args.Command, err)
+		log.Errorf("An error occurred trying to run the command %v: %v", args.Command, err)
 	}
 
 }

--- a/cfdtunnel/cfdtunnel_test.go
+++ b/cfdtunnel/cfdtunnel_test.go
@@ -192,8 +192,8 @@ func TestRunSubCommandMissing(t *testing.T) {
 
 	// Cast the error as *exec.ExitError and compare the result
 	e, ok := err.(*exec.ExitError)
-	assert.True(t, ok)
-	assert.Equal(t, "exit status 1", e.Error())
+	assert.False(t, ok)
+	assert.Nil(t, e)
 
 }
 


### PR DESCRIPTION
Avoid having a Fatal error and leaving the cloudflared process orphan.

With this PR, the flow will proceed and finish the execution killing the process itself in the end.