### PR TITLE
Change environment variables scope

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: test
 test:
-	gotest -v ./... -race -coverprofile=coverage.out -covermode=atomic
+	gotest -v ./... -coverprofile=coverage.out -covermode=atomic
 
 build:
 	go build

--- a/cfdtunnel/cfdtunnel_test.go
+++ b/cfdtunnel/cfdtunnel_test.go
@@ -175,9 +175,6 @@ func TestRunSubCommandStdOut(t *testing.T) {
 	r, w, _ := os.Pipe()
 	os.Stdout = w
 
-	// config, _ := readIniConfigFile("../test/config")
-	// tunnelCfg, _ := config.readConfigSection("alias1")
-
 	args.runSubCommand(TunnelConfig{})
 
 	w.Close()


### PR DESCRIPTION
Define the environment variables in the SubCommand process only and not on the global OS scope.

It avoids any kind of misbehaving due to concurrency using the same variable. Ie. HTTPS_PROXY