### PR TITLE
Removing sub-command CombinedOutput

### DIFF
--- a/cfdtunnel/cfdtunnel.go
+++ b/cfdtunnel/cfdtunnel.go
@@ -1,7 +1,6 @@
 package cfdtunnel
 
 import (
-	"fmt"
 	"os"
 	"os/exec"
 	"strings"
@@ -100,10 +99,14 @@ func (args Arguments) runSubCommand(tunnelConfig TunnelConfig) {
 	}
 
 	cmd := subCommand{exec.Command(args.Command, args.Args...)}
-	cmd.setupEnvironmentVariables(tunnelConfig.envVars)
-	output, err := cmd.CombinedOutput()
 
-	fmt.Println(string(output))
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	cmd.setupEnvironmentVariables(tunnelConfig.envVars)
+
+	err := cmd.Run()
 
 	if err != nil {
 		log.Errorf("An error occurred trying to run the command %v: %v", args.Command, err)

--- a/cfdtunnel/cfdtunnel_test.go
+++ b/cfdtunnel/cfdtunnel_test.go
@@ -185,7 +185,7 @@ func TestRunSubCommandStdOut(t *testing.T) {
 	out, _ := ioutil.ReadAll(r)
 	os.Stdout = rescueStdout
 
-	assert.Equal(t, "cfdtunnel.go\n\n", string(out))
+	assert.Equal(t, "cfdtunnel.go\n", string(out))
 }
 
 func TestRunSubCommandMissing(t *testing.T) {


### PR DESCRIPTION
This fixes an issue when there's some application trying to use standard stdin and stdout. Ie. Editor is called by kubectl to edit any live manifest