### PR TITLE
Custom config file

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,3 @@
+coverage:
+  status:
+    patch: off

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: daily

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -18,7 +18,7 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v1.29
+          version: v1.45.2
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir

--- a/cfdtunnel/cfdtunnel.go
+++ b/cfdtunnel/cfdtunnel.go
@@ -11,6 +11,7 @@ import (
 )
 
 const (
+	localClientDefaultUrl  = "127.0.0.1"
 	localClientDefaultPort = "5555"
 )
 
@@ -25,6 +26,7 @@ var (
 // It also stores preset Environment Variables needed to use together with the tunnel consumer.
 type TunnelConfig struct {
 	host    string
+	url     string
 	port    string
 	envVars []string
 }
@@ -183,6 +185,13 @@ func (cfg config) readConfigSection(section string) (TunnelConfig, error) {
 		return port
 	})
 
+	url := secs.Key("url").Validate(func(url string) string {
+		if len(url) == 0 {
+			return localClientDefaultUrl
+		}
+		return url
+	})
+
 	envVars := []string{}
 	if secs.Key("env").ValueWithShadows()[0] != "" {
 		envVars = secs.Key("env").ValueWithShadows()
@@ -190,6 +199,7 @@ func (cfg config) readConfigSection(section string) (TunnelConfig, error) {
 
 	return TunnelConfig{
 		host:    host.String(),
+		url:     url,
 		port:    port,
 		envVars: envVars,
 	}, nil

--- a/cfdtunnel/cfdtunnel.go
+++ b/cfdtunnel/cfdtunnel.go
@@ -11,13 +11,14 @@ import (
 )
 
 const (
-	iniConfigFile          = ".cfdtunnel/config"
 	localClientDefaultPort = "5555"
 )
 
 var (
 	// LogLevel sets the level of each log
 	LogLevel = log.WarnLevel
+	// IniConfigFile sets the path of config file
+	IniConfigFile = ".cfdtunnel/config"
 )
 
 // TunnelConfig struct stores data to launch cloudflared process such as hostname and port.
@@ -52,7 +53,7 @@ func init() {
 func (args Arguments) Execute() {
 	log.SetLevel(LogLevel)
 
-	config, err := readIniConfigFile(getHomePathIniFile(iniConfigFile))
+	config, err := readIniConfigFile(getHomePathIniFile(IniConfigFile))
 
 	if err != nil {
 		log.Fatalf("An error occurred reading your INI file: %v", err.Error())

--- a/cfdtunnel/cfdtunnel_test.go
+++ b/cfdtunnel/cfdtunnel_test.go
@@ -131,7 +131,7 @@ func contains(s []string, e string) bool {
 }
 
 func TestProxyTunnel(t *testing.T) {
-	tunnelConfig := TunnelConfig{"foo.bar", "1234", nil}
+	tunnelConfig := TunnelConfig{"foo.bar", "127.0.0.1", "1234", nil}
 	cmd := tunnelConfig.startProxyTunnel()
 	osPid, _ := os.FindProcess(cmd.Process.Pid)
 	assert.Equal(t, cmd.Process.Pid, osPid.Pid)
@@ -141,10 +141,10 @@ func TestProxyTunnel(t *testing.T) {
 
 func TestTunnelSamePort(t *testing.T) {
 
-	tunnelCfg := TunnelConfig{"foo.bar.first", "1234", nil}
+	tunnelCfg := TunnelConfig{"foo.bar.first", "127.0.0.1", "1234", nil}
 	cmd1 := tunnelCfg.startProxyTunnel()
 
-	tunnelCfg = TunnelConfig{"foo.bar.first", "1234", nil}
+	tunnelCfg = TunnelConfig{"foo.bar.first", "127.0.0.1", "1234", nil}
 	cmd2 := tunnelCfg.startProxyTunnel()
 
 	err := cmd2.Wait()
@@ -227,7 +227,7 @@ func TestNewTunnel(t *testing.T) {
 // TestSock5ProxyRunning launches the proxy tunnel and try to use it calling google.com
 // If the result does not have "connection refused" we assume the proxy is running and responding
 func TestSocks5ProxyRunning(t *testing.T) {
-	tunnelConfig := TunnelConfig{"foo.bar", "1234", nil}
+	tunnelConfig := TunnelConfig{"foo.bar", "127.0.0.1", "1234", nil}
 	cmd := tunnelConfig.startProxyTunnel()
 	dialSocksProxy, err := proxy.SOCKS5("tcp", "127.0.0.1:1234", nil, proxy.Direct)
 	if err != nil {


### PR DESCRIPTION
* Sets variable config file path to help when extending this library
* Using `url` from config file (or 127.0.0.1 as default) to allow using different values (eg 0.0.0.0)